### PR TITLE
To decode in UTF-8

### DIFF
--- a/src/main/java/com/github/JanLoebel/jsonschemavalidation/advice/JsonValidationRequestBodyControllerAdvice.java
+++ b/src/main/java/com/github/JanLoebel/jsonschemavalidation/advice/JsonValidationRequestBodyControllerAdvice.java
@@ -85,7 +85,7 @@ public class JsonValidationRequestBodyControllerAdvice implements RequestBodyAdv
     }
 
     private InputStream fromString(String body) {
-        return new ByteArrayInputStream(body.getBytes());
+        return new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8));
     }
 
     private HttpInputMessage buildHttpInputMessage(String body, HttpHeaders httpHeaders) {


### PR DESCRIPTION
On Windows in a Japanese environment, the conversion of character strings to byte codes is environment-dependent, so the strings are converted to SJIS and garbled in subsequent processing, so please change the conversion to UTF-8.