### PR TITLE
Make JSON schema provider a bean

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,28 @@ public BooksConroller {
 }
 ```
 
+The schemas are read by a bean that implements the `JsonSchemaProvider` interface. By default, the `DefaultJsonSchemaProvider` is used, which can load schemas by a URL or from the classpath. If necessary, a custom schema provider can be implemented and configured:
+
+```
+@ConditionalOnProperty(prefix = "json.schema.validation", name = "schemaProvider", havingValue = "custom")
+@Component
+public class CustomJsonSchemaProvider implements JsonSchemaProvider {
+     JsonSchema loadSchema(String url) {
+         // Create and return a JSON schema...
+     }
+
+    void handleValidationMessages(Collection<ValidationMessage> validationMessages) {
+         // Handle validation messages...
+    }
+}
+```
+
+Configure the schema provider in `application.properties`:
+
+```
+json.schema.validation.schemaProvider=custom
+```
+
 ## Example project
 Head over to [http://github.com/JanLoebel/json-schema-validation-starter-example](http://github.com/JanLoebel/json-schema-validation-starter-example) to checkout the sample project.
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>json-schema-validator</artifactId>
             <version>${json-schema-validator.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -55,6 +60,11 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/com/github/JanLoebel/jsonschemavalidation/JsonSchemaValidationAutoConfiguration.java
+++ b/src/main/java/com/github/JanLoebel/jsonschemavalidation/JsonSchemaValidationAutoConfiguration.java
@@ -2,7 +2,8 @@ package com.github.JanLoebel.jsonschemavalidation;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.JanLoebel.jsonschemavalidation.advice.JsonValidationRequestBodyControllerAdvice;
-import com.github.JanLoebel.jsonschemavalidation.provider.DefaultJsonSchemaProvider;
+import com.github.JanLoebel.jsonschemavalidation.provider.JsonSchemaProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,10 +11,13 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class JsonSchemaValidationAutoConfiguration {
 
+    @Autowired
+    private JsonSchemaProvider jsonSchemaProvider;
+
     @Bean
     @ConditionalOnMissingBean
     public JsonValidationRequestBodyControllerAdvice jsonValidationRequestBodyControllerAdvice(ObjectMapper objectMapper) {
-        return new JsonValidationRequestBodyControllerAdvice(objectMapper, new DefaultJsonSchemaProvider());
+        return new JsonValidationRequestBodyControllerAdvice(objectMapper, jsonSchemaProvider);
     }
 
 }

--- a/src/main/java/com/github/JanLoebel/jsonschemavalidation/provider/CacheableJsonSchemaProvider.java
+++ b/src/main/java/com/github/JanLoebel/jsonschemavalidation/provider/CacheableJsonSchemaProvider.java
@@ -1,10 +1,14 @@
 package com.github.JanLoebel.jsonschemavalidation.provider;
 
 import com.networknt.schema.JsonSchema;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+@ConditionalOnProperty(prefix = "json.schema.validation", name = "schemaProvider", havingValue = "cacheable")
+@Component
 public class CacheableJsonSchemaProvider extends DefaultJsonSchemaProvider {
 
     private final Map<String, JsonSchema> cache = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/JanLoebel/jsonschemavalidation/provider/DefaultJsonSchemaProvider.java
+++ b/src/main/java/com/github/JanLoebel/jsonschemavalidation/provider/DefaultJsonSchemaProvider.java
@@ -1,13 +1,21 @@
 package com.github.JanLoebel.jsonschemavalidation.provider;
 
-import com.networknt.schema.*;
 import com.github.JanLoebel.jsonschemavalidation.JsonSchemaValidationException;
+import com.networknt.schema.*;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Component;
 import org.springframework.util.ResourceUtils;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.Collection;
 
+
+@ConditionalOnProperty(prefix = "json.schema.validation", name = "schemaProvider", havingValue = "default")
+@Component
 public class DefaultJsonSchemaProvider implements JsonSchemaProvider {
 
     @Override

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,1 @@
+json.schema.validation.schemaProvider=default

--- a/src/test/java/com/github/JanLoebel/jsonschemavalidation/CustomJsonSchemaProvider.java
+++ b/src/test/java/com/github/JanLoebel/jsonschemavalidation/CustomJsonSchemaProvider.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2021 Daniel Murygin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.JanLoebel.jsonschemavalidation;
+
+import com.github.JanLoebel.jsonschemavalidation.provider.DefaultJsonSchemaProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * A custom JSON schema provider used only in tests.
+ *
+ * @author Daniel Murygin
+ */
+@ConditionalOnProperty(prefix = "json.schema.validation", name = "schemaProvider", havingValue = "custom")
+@Component
+public class CustomJsonSchemaProvider extends DefaultJsonSchemaProvider {
+
+}

--- a/src/test/java/com/github/JanLoebel/jsonschemavalidation/CustomSchemaProviderTest.java
+++ b/src/test/java/com/github/JanLoebel/jsonschemavalidation/CustomSchemaProviderTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021 Daniel Murygin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.JanLoebel.jsonschemavalidation;
+
+import com.github.JanLoebel.jsonschemavalidation.provider.JsonSchemaProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test checks if a custom JSON schema provider selected in the application.properties is used.
+ *
+ * @author Daniel Murygin
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@ActiveProfiles("customProvider")
+public class CustomSchemaProviderTest {
+
+    @Autowired
+    private JsonSchemaProvider jsonSchemaProvider;
+
+    @Test
+    public void testProviderClass() {
+        assertThat(jsonSchemaProvider!=null);
+        assertThat(jsonSchemaProvider.getClass().equals(CustomJsonSchemaProvider.class));
+    }
+}

--- a/src/test/java/com/github/JanLoebel/jsonschemavalidation/DefaultSchemaProviderTest.java
+++ b/src/test/java/com/github/JanLoebel/jsonschemavalidation/DefaultSchemaProviderTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Daniel Murygin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.JanLoebel.jsonschemavalidation;
+
+import com.github.JanLoebel.jsonschemavalidation.provider.DefaultJsonSchemaProvider;
+import com.github.JanLoebel.jsonschemavalidation.provider.JsonSchemaProvider;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * This test checks if the DefaultJsonSchemaProvider is used if no other is configured in the application.properties.
+ *
+ * @author Daniel Murygin
+ */
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+public class DefaultSchemaProviderTest {
+
+    @Autowired
+    private JsonSchemaProvider jsonSchemaProvider;
+
+    @Test
+    public void testProviderClass() {
+        assertThat(jsonSchemaProvider!=null);
+        assertThat(jsonSchemaProvider.getClass().equals(DefaultJsonSchemaProvider.class));
+    }
+}

--- a/src/test/java/com/github/JanLoebel/jsonschemavalidation/TestApplication.java
+++ b/src/test/java/com/github/JanLoebel/jsonschemavalidation/TestApplication.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021 Daniel Murygin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ * LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package com.github.JanLoebel.jsonschemavalidation;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+
+/**
+ * This Spring Boot application is used only in the tests.
+ *
+ * To run Spring Boot Tests, an application class annotated with @SpringBootApplication is required. Since there is no
+ * Spring Boot application in the source code of the schema validator, such a class must be available especially for the
+ * tests.
+ *
+ * @author Daniel Murygin
+ */
+@SpringBootApplication
+public class TestApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TestApplication.class, args);
+    }
+}

--- a/src/test/resources/application-customProvider.properties
+++ b/src/test/resources/application-customProvider.properties
@@ -1,0 +1,1 @@
+json.schema.validation.schemaProvider=custom


### PR DESCRIPTION
- Make DefaultJsonSchemaProvider and CacheableJsonSchemaProvider a component bean that is only created if configured in the properties.
- Add an autowired JsonSchemaProvider bean to configuration class.
- Add test to check if DefaultJsonSchemaProvider is used without changing properties.
- Add test to check if if a custom JSON schema provider selected in the application.properties is used.